### PR TITLE
MooseX::ClassAttribute 0.27 is compatible with new Moose

### DIFF
--- a/lib/MooseX/AlwaysCoerce.pm
+++ b/lib/MooseX/AlwaysCoerce.pm
@@ -6,7 +6,7 @@ use warnings;
 
 use namespace::autoclean 0.12;
 use Moose ();
-use MooseX::ClassAttribute 0.24 ();
+use MooseX::ClassAttribute 0.27 ();
 use Moose::Exporter;
 use Moose::Util::MetaRole;
 use Carp;


### PR DESCRIPTION
prevents problems if Moose is upgraded
